### PR TITLE
set app window to be single instance

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -37,6 +37,19 @@ isDev = (isDev) || process.env.DEBUG_SCRATCHJR;
 
 const { app, dialog, BrowserWindow, BrowserView, ipcMain, Menu } = require('electron');  
 
+var myWindow = null;
+
+var shouldQuit = app.makeSingleInstance(function(commandLine, workingDirectory) {
+  // Someone tried to run a second instance, we should focus our window.
+  if (myWindow) {
+    if (myWindow.isMinimized()) myWindow.restore();
+    myWindow.focus();
+  }
+});
+
+if (shouldQuit) {
+  app.quit();
+}
 
 
 /* eslint-enable import/extensions */  // --> ON


### PR DESCRIPTION
This commit makes electron window single instance, avoiding the multiple writes in the .sqlite file, which causes corruption