### PR TITLE
Add complete protocol in one href to scratchjr.org

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -83,7 +83,7 @@
            this <span class='experimental'>important disclaimer about this experimental version</span>:
            <br/>
            <div class='scratchDisclaimer'>
-           Scratch and ScratchJr are trademarks of Massachusetts Institute of Technology, which does not sponsor, endorse, or authorize this content. See <a href="scratchjr.org">scratchjr.org</a> for more information.
+           Scratch and ScratchJr are trademarks of Massachusetts Institute of Technology, which does not sponsor, endorse, or authorize this content. See <a href="https://www.scratchjr.org">scratchjr.org</a> for more information.
            </div>
            
            


### PR DESCRIPTION
Dear @jfo8000

In this PR I propose to fix a broken link in https://jfo8000.github.io/ScratchJr-Desktop/ because `https://` need to be added before the domain name. I also added `www.` for consistency because you have also the `www.` subdomain in the other links in that page.

Thank you.